### PR TITLE
fix: correccion de busqueda y filtros , sort

### DIFF
--- a/app/Http/Requests/Product/ShowRequest.php
+++ b/app/Http/Requests/Product/ShowRequest.php
@@ -39,7 +39,7 @@ class ShowRequest extends FormRequest
     {
         $this->merge(
         [
-            'id' => $this->route('id'),
+            'id' => $this->route('product'),
         ]);
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -104,6 +104,7 @@ class Product extends Model
      */
     public function scopeFilter($query, array $filters)
     {
+        $sortByPrice = null;
         foreach ($filters as $filter) {
             // Filtros especiales para precios
             if (isset($filter['field']) && $filter['field'] === 'price') {


### PR DESCRIPTION
Modificaciones en los siguientes archivos
app/Models/Product.php : correccion a sortByPrice. inicializa en null para no romper los otros filtros.
app/Http/Requests/Product/ShowRequest.php: solucion a status 422
$this->merge(
[
'id' => $this->route('product'), <-- antes estaba con id , provocando error en la busqueda /api/products/1 <- producto id
]);

Verificar en Postgres si permite la busqueda por fulltext
CREATE EXTENSION IF NOT EXISTS pg_trgm; (en mi local no lo tenia fallando la busqueda por nombre)