### PR TITLE
refactor: reubica la ruta catch-all al final del archivo de rutas y elimina la versión anterior

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -88,11 +88,6 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Rutas de Webpay
     Route::post('/orders/pay', [OrderController::class, 'payOrder']);
-    Route::any('{url}', function()
-    {
-        return response()->json(['message' => 'Method Not Allowed.'], 405);
-    })->where('url', '.*');
-
 });
 
 //Se sacan de la autenticacion porque es confirmacion de pago.
@@ -101,3 +96,8 @@ Route::middleware('auth:sanctum')->group(function () {
 Route::get('/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
 Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
+
+// Ruta catch-all al final
+Route::any('{url}', function() {
+    return response()->json(['message' => 'Method Not Allowed.'], 405);
+})->where('url', '.*');


### PR DESCRIPTION
refactor: reubica la ruta catch-all al final del archivo de rutas y elimina la versión anterior

Se hace para que no arroje error en el front mas tarde