### PR TITLE
fix: #120 - Actualiza el seeder de CartItem ,Order y CartItem en DatabaseSeeder.

### DIFF
--- a/database/seeders/CartItemSeeder.php
+++ b/database/seeders/CartItemSeeder.php
@@ -35,7 +35,8 @@ class CartItemSeeder extends Seeder
                 CartItem::create([
                     'user_id' => $user->id,
                     'product_id' => $product->id,
-                    'quantity' => $quantity
+                    'quantity' => $quantity,
+                    'unit' => $product->prices->where('is_active', true)->first()->unit,
                 ]);
             }
         }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,8 +21,8 @@ class DatabaseSeeder extends Seeder
                 ProductSeeder::class,
                 PaymentMethodSeeder::class,
                 RolesAndPermissionsSeeder::class,
-                // OrderSeeder::class,
-                // CartItemSeeder::class,
+                OrderSeeder::class,
+                CartItemSeeder::class,
             ]);
 
         }else{

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -36,6 +36,14 @@ class OrderSeeder extends Seeder
                 $subtotal = 0;
                 $amount = 0;
 
+                $user = User::find($userId);
+                $address = $user->addresses()->where('type', 'billing')->first();
+                $order_meta = json_encode([
+                    'user' => $user->toArray(),
+                    'address' => $address ? $address->toArray() : null,
+                ]);
+
+       
                 $order = \App\Models\Order::create([
                     'user_id' => $userId,
                     'subtotal' => 0,
@@ -43,6 +51,7 @@ class OrderSeeder extends Seeder
                     'status' => fake()->randomElement([
                         'pending', 'processing', 'on_hold', 'completed', 'canceled', 'refunded', 'failed'
                     ]),
+                    'order_meta' => $order_meta,
                     'created_at' => $date,
                     'updated_at' => $date,
                 ]);


### PR DESCRIPTION
Esta *pull request* actualiza varios *seeders* de base de datos para mejorar el proceso de siembra de datos, añadiendo nuevos campos y reactivando ciertos *seeders*. Los cambios más importantes incluyen la adición del campo `unit` en la siembra de `CartItem`, la reactivación de `OrderSeeder` y `CartItemSeeder`, y la mejora del `OrderSeeder` con metadatos adicionales.

### Mejoras en `CartItemSeeder`:

* Se añadió un campo `unit` a la lógica de creación de `CartItem`, obteniendo el valor de la unidad de precio activa del producto asociado. (`database/seeders/CartItemSeeder.php`, [[database/seeders/CartItemSeeder.phpL38-R39](diffhunk://#diff-9f9734c399b0d10be838bd93d46f90817038ebf49f8b6b70b5946a7b9d748355L38-R39)](diffhunk://#diff-9f9734c399b0d10be838bd93d46f90817038ebf49f8b6b70b5946a7b9d748355L38-R39))

### Actualizaciones en `DatabaseSeeder`:

* Se reactivaron `OrderSeeder` y `CartItemSeeder` en la clase `DatabaseSeeder` para incluirlos en el proceso general de siembra. (`database/seeders/DatabaseSeeder.php`, [[database/seeders/DatabaseSeeder.phpL24-R25](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dL24-R25)](diffhunk://#diff-ccad8b4ee6013765c2bc672aa0515f8e99e42949c914cce01e0cb2b4e882775dL24-R25))

### Mejoras en `OrderSeeder`:

* Se introdujo `order_meta` para almacenar metadatos adicionales, incluyendo detalles del usuario y dirección de facturación, en la lógica de creación de `Order`. (`database/seeders/OrderSeeder.php`, [[database/seeders/OrderSeeder.phpR39-R54](diffhunk://#diff-71839b65347d20e9a91e1f5dce14bcb2a800e882506ee639e7847f3d2fbb1fe7R39-R54)](diffhunk://#diff-71839b65347d20e9a91e1f5dce14bcb2a800e882506ee639e7847f3d2fbb1fe7R39-R54))