### PR TITLE
refactor: #122 - Unificar endpoints de pago de la orden

### DIFF
--- a/app/Http/Requests/Orders/PayOrderRequest.php
+++ b/app/Http/Requests/Orders/PayOrderRequest.php
@@ -14,19 +14,12 @@ class PayOrderRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'order_id' => 'required|exists:orders,id',
-            'user_id' => 'required|exists:users,id|integer'
         ];
     }
 
     public function messages(): array
     {
         return [
-            'order_id.required' => 'El ID de la orden es requerido',
-            'order_id.exists' => 'La orden no existe',
-            'user_id.required' => 'El ID del usuario es requerido',
-            'user_id.exists' => 'El usuario no existe',
-            'user_id.integer' => 'El ID del usuario debe ser un número entero'
         ];
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,9 +87,6 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Rutas de orden
     Route::get('/orders', [OrderController::class, 'index']);
-    Route::post('/orders/create-from-cart', [OrderController::class, 'createFromCart']);
-
-    // Rutas de Webpay
     Route::post('/orders/pay', [OrderController::class, 'payOrder']);
     
    


### PR DESCRIPTION
Esta *pull request* refactoriza el proceso de creación y pago de pedidos en el `OrderController`, simplificando las firmas de los métodos, eliminando validaciones de solicitudes innecesarias y optimizando la lógica. Además, actualiza las rutas de la API y elimina las reglas de validación del `PayOrderRequest`.

### Refactorización en `OrderController`:

* `app/Http/Controllers/Api/OrderController.php`:

  * Se eliminó el parámetro `CreateFromCartRequest` del método `createFromCart` y se ajustó su lógica para que ya no dependa de la validación de la solicitud.
  * Se modificó el método `payOrder` para llamar directamente a `createFromCart`, eliminando la necesidad de `PayOrderRequest` y su validación. Se simplificaron las comprobaciones de existencia y estado del pedido.

### Limpieza de validaciones:

* `app/Http/Requests/Orders/PayOrderRequest.php`:

  * Se eliminaron las reglas de validación y los mensajes de error para `order_id` y `user_id`, ya que ya no son necesarios debido a la lógica refactorizada.

### Actualizaciones en rutas de API:

* `routes/api.php`:

  * Se eliminó la ruta `/orders/create-from-cart`, ya que su funcionalidad fue integrada en el método `payOrder`.
