### PR TITLE
Notificaciones de push para Discord

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -1,0 +1,17 @@
+name: Notify Discord on main push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        run: |
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{\"content\": \"🚀 Nuevo push a **develop** en **${{ github.repository }}** por **${{ github.actor }}**.\n📄 *${{ github.event.head_commit.message }}*\n👉 [Ver commit](https://github.com/${{ github.repository }}/commit/${{ github.sha }})\", \"username\": \"GitHub Bot\"}" \
+          ${{ secrets.DISCORD_BACKEND_WEBHOOK_URL }}


### PR DESCRIPTION
Se agrega un workflow de GitHub Actions para notificar automáticamente a un canal de Discord cada vez que se haga un push a la rama main del repositorio backend.

El mensaje enviado incluye:

-El nombre del repositorio

-El usuario que hizo el push

-El mensaje del último commit

-Un enlace directo al commit en GitHub


Ejemplo:

![image](https://github.com/user-attachments/assets/2fe28019-f2c5-42b7-a613-b82f40f45eae)
