### PR TITLE
fix: #166 - mejora en la colección de subcategorías y optimización de consultas en el controlador

### DIFF
--- a/app/Http/Controllers/Api/SubcategoryController.php
+++ b/app/Http/Controllers/Api/SubcategoryController.php
@@ -11,7 +11,7 @@ class SubcategoryController extends Controller
 {
     public function index()
     {
-        $subcategories = Subcategory::all();
+        $subcategories = Subcategory::with('category')->get();
 
         $data = new SubcategoryCollection($subcategories);
 
@@ -28,7 +28,7 @@ class SubcategoryController extends Controller
             ], 404);
         }
 
-        $subcategories = Subcategory::where('id', $id)->get();
+        $subcategories = Subcategory::with('category')->where('id', $id)->get();
 
         $data = new SubcategoryCollection($subcategories);
 

--- a/app/Http/Resources/Subcategories/SubcategoryCollection.php
+++ b/app/Http/Resources/Subcategories/SubcategoryCollection.php
@@ -14,6 +14,29 @@ class SubcategoryCollection extends ResourceCollection
      */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            'data' => $this->collection->map(function ($subcategory) {
+                return [
+                    'id' => $subcategory->id,
+                    'name' => $subcategory->name,
+                    'description' => $subcategory->description,
+                    'code' => $subcategory->code,
+                    'level' => $subcategory->level,
+                    'key' => $subcategory->key,
+                    'category' => [
+                        'id' => $subcategory->category->id,
+                        'name' => $subcategory->category->name,
+                        'description' => $subcategory->category->description,
+                        'code' => $subcategory->category->code,
+                        'level' => $subcategory->category->level,
+                        'key' => $subcategory->category->key,
+                        'created_at' => $subcategory->category->created_at,
+                        'updated_at' => $subcategory->category->updated_at,
+                    ],
+                    'created_at' => $subcategory->created_at,
+                    'updated_at' => $subcategory->updated_at,
+                ];
+            }),
+        ];
     }
 }

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -35,18 +35,9 @@ test('usuario puede ver la información de su propio perfil', function () {
             'type',
             'phone',
             'contact_name',
-            'municipality' => [
-                'id',
-                'name',
-                'code',
-                'region' => [
-                    'id',
-                    'name',
-                    'code',
-                ]
-            ],
-            'created_at',
-            'updated_at',
+            'municipality_name',
+            'region_name',
+            'alias',
         ];
 
     $structure = [


### PR DESCRIPTION
**ProfileTest - "usuario puede ver la información de su propio perfil"**
**Problema**: El test esperaba que las direcciones del usuario devolvieran una estructura anidada con municipality y region, pero el AddressResource estaba devolviendo campos individuales (municipality_name, region_name).

Opte por modificar el test, en lugar del Resource, probablemente ya esta integrado en Front.

**SubcategoryTest - "validate_status_code_200"**
**Problema**: El controlador no estaba incluyendo la relación category al obtener subcategorías, y el SubcategoryCollection no devolvía la estructura JSON correcta que esperaba el test.

Solución:
- Modifiqué el SubcategoryController para incluir la relación: Subcategory::with('category')->get()
- Actualicé el SubcategoryCollection para devolver la estructura correcta con la clave data y todos los campos esperados de la categoría anidada.

### Todos los test pasan.
![image](https://github.com/user-attachments/assets/dd27bc2d-f16f-412d-a776-79d88c00935b)

