### PR TITLE
Feature #229: Restricción de Edición de Usuarios

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -151,17 +151,6 @@ class UserController extends Controller
                 ], 404);
             }
 
-            // Guardar datos originales para comparar cambios
-            $originalData = $user->toArray();
-
-            // Actualizar datos básicos
-            //$user->name = $data['name'];
-            //$user->email = $data['email'];
-            //$user->phone = $data['phone'];
-            //$user->rut = $data['rut'];
-            //$user->business_name = $data['business_name'];
-            //$user->is_active = $data['is_active'];
-
             // Actualizar contraseña si se proporciona
             $passwordChanged = false;
             $newPassword = null;
@@ -171,24 +160,24 @@ class UserController extends Controller
                 $passwordChanged = true;
             }
 
-            $user->save();
+            // Solo guardar si se cambió la contraseña
+            if ($passwordChanged) {
+                $user->save();
+            }
 
             // Actualizar roles si se proporcionan
             if (isset($data['roles']) && is_array($data['roles'])) {
                 $user->syncRoles($data['roles']);
             }
 
-            // Verificar si hubo cambios significativos
-            $hasSignificantChanges = $this->hasSignificantChanges($originalData, $user->toArray());
-
-            // Enviar email de notificación solo si hay cambios significativos
-            if ($hasSignificantChanges || $passwordChanged) {
+            // Enviar email de notificación solo si se cambió la contraseña
+            if ($passwordChanged) {
                 try {
                     Mail::to($user->email)->send(
                         new UserNotificationMail(
                             $user, 
                             'updated', 
-                            $passwordChanged ? $newPassword : null
+                            $newPassword
                         )
                     );
                 } catch (\Exception $e) {

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -155,12 +155,12 @@ class UserController extends Controller
             $originalData = $user->toArray();
 
             // Actualizar datos básicos
-            $user->name = $data['name'];
-            $user->email = $data['email'];
-            $user->phone = $data['phone'];
-            $user->rut = $data['rut'];
-            $user->business_name = $data['business_name'];
-            $user->is_active = $data['is_active'];
+            //$user->name = $data['name'];
+            //$user->email = $data['email'];
+            //$user->phone = $data['phone'];
+            //$user->rut = $data['rut'];
+            //$user->business_name = $data['business_name'];
+            //$user->is_active = $data['is_active'];
 
             // Actualizar contraseña si se proporciona
             $passwordChanged = false;

--- a/app/Http/Requests/Users/UpdateRequest.php
+++ b/app/Http/Requests/Users/UpdateRequest.php
@@ -29,13 +29,7 @@ class UpdateRequest extends FormRequest
         return
         [
             'id' => 'bail|integer|exists:users,id',
-            //'name' => 'bail|required|string|max:255',
-            //'email' => ['bail', 'required', 'email', 'max:255', Rule::unique('users')->ignore($userId)],
             'password' => ['bail', 'sometimes', 'confirmed', Password::min(8)->letters()],
-            //'phone' => 'bail|required|string|max:15',
-            //'rut' => ['bail', 'required', 'string', 'max:12', Rule::unique('users')->ignore($userId), new ValidateRut],
-            //'business_name' => 'bail|required|string|max:255',
-            //'is_active' => 'bail|required|boolean',
             'roles' => 'bail|sometimes|array',
             'roles.*' => 'bail|string|exists:roles,name',
         ];
@@ -49,17 +43,7 @@ class UpdateRequest extends FormRequest
     public function messages(): array
     {
         return [
-            //'name.required' => 'El nombre es requerido.',
-            //'email.required' => 'El email es requerido.',
-            //'email.email' => 'El email debe tener un formato válido.',
-            //'email.unique' => 'Este email ya está registrado.',
             'password.confirmed' => 'La confirmación de contraseña no coincide.',
-            //'phone.required' => 'El teléfono es requerido.',
-            //'rut.required' => 'El RUT es requerido.',
-            //'rut.unique' => 'Este RUT ya está registrado.',
-            //'business_name.required' => 'El nombre de la empresa es requerido.',
-            //'is_active.required' => 'El estado es requerido.',
-            //'is_active.boolean' => 'El estado debe ser verdadero o falso.',
             'roles.array' => 'Los roles deben ser un arreglo.',
             'roles.*.exists' => 'Uno o más roles no existen.',
         ];

--- a/app/Http/Requests/Users/UpdateRequest.php
+++ b/app/Http/Requests/Users/UpdateRequest.php
@@ -29,13 +29,13 @@ class UpdateRequest extends FormRequest
         return
         [
             'id' => 'bail|integer|exists:users,id',
-            'name' => 'bail|required|string|max:255',
-            'email' => ['bail', 'required', 'email', 'max:255', Rule::unique('users')->ignore($userId)],
+            //'name' => 'bail|required|string|max:255',
+            //'email' => ['bail', 'required', 'email', 'max:255', Rule::unique('users')->ignore($userId)],
             'password' => ['bail', 'sometimes', 'confirmed', Password::min(8)->letters()],
-            'phone' => 'bail|required|string|max:15',
-            'rut' => ['bail', 'required', 'string', 'max:12', Rule::unique('users')->ignore($userId), new ValidateRut],
-            'business_name' => 'bail|required|string|max:255',
-            'is_active' => 'bail|required|boolean',
+            //'phone' => 'bail|required|string|max:15',
+            //'rut' => ['bail', 'required', 'string', 'max:12', Rule::unique('users')->ignore($userId), new ValidateRut],
+            //'business_name' => 'bail|required|string|max:255',
+            //'is_active' => 'bail|required|boolean',
             'roles' => 'bail|sometimes|array',
             'roles.*' => 'bail|string|exists:roles,name',
         ];
@@ -49,17 +49,17 @@ class UpdateRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'name.required' => 'El nombre es requerido.',
-            'email.required' => 'El email es requerido.',
-            'email.email' => 'El email debe tener un formato válido.',
-            'email.unique' => 'Este email ya está registrado.',
+            //'name.required' => 'El nombre es requerido.',
+            //'email.required' => 'El email es requerido.',
+            //'email.email' => 'El email debe tener un formato válido.',
+            //'email.unique' => 'Este email ya está registrado.',
             'password.confirmed' => 'La confirmación de contraseña no coincide.',
-            'phone.required' => 'El teléfono es requerido.',
-            'rut.required' => 'El RUT es requerido.',
-            'rut.unique' => 'Este RUT ya está registrado.',
-            'business_name.required' => 'El nombre de la empresa es requerido.',
-            'is_active.required' => 'El estado es requerido.',
-            'is_active.boolean' => 'El estado debe ser verdadero o falso.',
+            //'phone.required' => 'El teléfono es requerido.',
+            //'rut.required' => 'El RUT es requerido.',
+            //'rut.unique' => 'Este RUT ya está registrado.',
+            //'business_name.required' => 'El nombre de la empresa es requerido.',
+            //'is_active.required' => 'El estado es requerido.',
+            //'is_active.boolean' => 'El estado debe ser verdadero o falso.',
             'roles.array' => 'Los roles deben ser un arreglo.',
             'roles.*.exists' => 'Uno o más roles no existen.',
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -176,6 +176,25 @@ class User extends Authenticatable
                 continue;
             }
 
+            // Filtro especial para buscar en name o email
+            if ($filter['field'] === 'name_or_email' && !empty($filter['value'])) {
+                $value = $filter['value'];
+                $operator = $filter['operator'] ?? 'ILIKE';
+                
+                // Si es un operador LIKE/ILIKE, añadir los wildcards
+                if (in_array($operator, ['LIKE', 'ILIKE'])) {
+                    $searchValue = "%{$value}%";
+                } else {
+                    $searchValue = $value;
+                }
+                
+                $query->where(function ($q) use ($operator, $searchValue) {
+                    $q->where('name', $operator, $searchValue)
+                      ->orWhere('email', $operator, $searchValue);
+                });
+                continue;
+            }
+
             $field = array_find($this->allowedFilters, function ($item) use ($filter) {
                 return $item['field'] === $filter['field'];
             });

--- a/tests/Feature/AdminUserTest.php
+++ b/tests/Feature/AdminUserTest.php
@@ -84,12 +84,8 @@ test('usuario con permisos puede actualizar usuarios', function () {
     $user->assignRole('cliente');
     
     $updateData = [
-        'name' => 'Updated Name',
-        'email' => $user->email,
-        'phone' => (string) $user->phone,
-        'rut' => $user->rut,
-        'business_name' => 'Updated Business',
-        'is_active' => false,
+        'password' => 'newpassword123',
+        'password_confirmation' => 'newpassword123',
         'roles' => ['admin']
     ];
 
@@ -105,16 +101,22 @@ test('usuario con permisos puede actualizar usuarios', function () {
             'password_changed'
         ]);
 
+    // Verificar que los datos básicos NO cambiaron (solo se pueden cambiar password y roles)
     $this->assertDatabaseHas('users', [
         'id' => $user->id,
-        'name' => 'Updated Name',
-        'business_name' => 'Updated Business',
-        'is_active' => false
+        'name' => 'Original Name',
+        'business_name' => 'Original Business',
     ]);
 
+    // Verificar que los roles sí cambiaron
     $user->refresh();
     expect($user->hasRole('admin'))->toBeTrue();
     expect($user->hasRole('cliente'))->toBeFalse();
+    
+    // Verificar que se reportó el cambio de contraseña
+    $response->assertJson([
+        'password_changed' => true
+    ]);
 });
 
 test('usuario con permisos puede eliminar usuarios', function () {


### PR DESCRIPTION
## Resumen de Cambios - Feature #229: Restricción de Edición de Usuarios

  Contexto

  Se implementó una restricción de seguridad donde los administradores ya no pueden editar los datos personales de otros usuarios, limitando las modificaciones únicamente a contraseñas y roles.

  Commits Realizados:

  1. b5b7d36 - Desactivación de campos de datos personales
  - Archivos: UserController.php, UpdateRequest.php, User.model.php
  - Cambios: Se implementó filtrado por nombre y email, y se comenzó la restricción de campos editables

  2. de28111 - Lógica de actualización restringida
  - Archivos: UserController.php, UpdateRequest.php, AdminUserTest.php
  - Cambios: Se actualizó el controlador y request para permitir solo cambios en contraseña y roles, eliminando la capacidad de modificar datos personales (nombre, email, teléfono, RUT, etc.)

  3. 30a83ae - Actualización de tests
  - Archivos: PersonalInformationTest.php
  - Cambios: Se corrigieron las pruebas para reflejar la nueva funcionalidad:
    - Tests de validación de datos personales → Tests de validación de contraseña/roles
    - Tests de campos requeridos → Tests de actualización opcional
    - Tests de actualización completa → Tests de actualización parcial (solo password/roles)

  Resultado Final

  - ✅ Los administradores pueden cambiar contraseñas y asignar roles
  - ❌ Los administradores NO pueden modificar datos personales (nombre, email, teléfono, RUT, empresa)
  - ✅ Todos los tests pasan correctamente
  - ✅ Se mantiene la seguridad y integridad de los datos de usuario