### PR TITLE
feat: #223 - Funcionalidad para habilitar/deshabilitar el mensaje al cliente

### DIFF
--- a/app/Http/Controllers/Api/SiteinfoController.php
+++ b/app/Http/Controllers/Api/SiteinfoController.php
@@ -184,6 +184,7 @@ class SiteinfoController extends Controller
             'banner_enabled' => 'required|boolean',
             'modal_image' => 'nullable|image',
             'modal_enabled' => 'required|boolean',
+            'message_enabled' => 'required|boolean',
         ]);
 
         $customerMessage = Siteinfo::where('key', 'customer_message')->first();
@@ -220,6 +221,12 @@ class SiteinfoController extends Controller
         Siteinfo::updateOrCreate(
             ['key' => 'customer_message'],
             ['value' => $value]
+        );
+
+        // Guardar el estado enabled por separado
+        Siteinfo::updateOrCreate(
+            ['key' => 'customer_message_enabled'],
+            ['value' => $data['message_enabled']]
         );
 
         return response()->json(['message' => 'Mensaje de bienvenida actualizado correctamente.']);
@@ -277,26 +284,4 @@ class SiteinfoController extends Controller
         );
     }
 
-    /**
-     * Toggle the customer message enabled status.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function toggleCustomerMessageEnabled(Request $request)
-    {
-        $data = $request->validate([
-            'enabled' => 'required|boolean',
-        ]);
-
-        Siteinfo::updateOrCreate(
-            ['key' => 'customer_message_enabled'],
-            ['value' => $data['enabled']]
-        );
-
-        return response()->json([
-            'enabled' => $data['enabled'],
-            'message' => 'Estado del mensaje de cliente actualizado exitosamente'
-        ]);
-    }
 }

--- a/app/Http/Controllers/Api/SiteinfoController.php
+++ b/app/Http/Controllers/Api/SiteinfoController.php
@@ -20,6 +20,7 @@ class SiteinfoController extends Controller
         $header = Siteinfo::where('key', 'header')->first();
         $footer = Siteinfo::where('key', 'footer')->first();
         $social = Siteinfo::where('key', 'social_media')->first();
+        $customerMessageEnabled = Siteinfo::where('key', 'customer_message_enabled')->first();
 
         return response()->json([
             'header' => $header ? $header->value : (object)[
@@ -36,6 +37,7 @@ class SiteinfoController extends Controller
                     'link' => ''
                 ]
             ],
+            'customer_message_enabled' => $customerMessageEnabled ? (bool)$customerMessageEnabled->value : false,
         ]);
     }   
     
@@ -273,5 +275,28 @@ class SiteinfoController extends Controller
                 'data' => $data
             ]
         );
+    }
+
+    /**
+     * Toggle the customer message enabled status.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function toggleCustomerMessageEnabled(Request $request)
+    {
+        $data = $request->validate([
+            'enabled' => 'required|boolean',
+        ]);
+
+        Siteinfo::updateOrCreate(
+            ['key' => 'customer_message_enabled'],
+            ['value' => $data['enabled']]
+        );
+
+        return response()->json([
+            'enabled' => $data['enabled'],
+            'message' => 'Estado del mensaje de cliente actualizado exitosamente'
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -170,6 +170,7 @@ Route::middleware(['auth:sanctum', 'role:editor|admin|superadmin'])->group(funct
     Route::put('/terms', [SiteinfoController::class, 'updateTerms']);
     Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy']);
     Route::post('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
+    Route::put('/customer-message/enabled', [SiteinfoController::class, 'toggleCustomerMessageEnabled']);
 });
 
 // Ruta catch-all al final

--- a/routes/api.php
+++ b/routes/api.php
@@ -170,7 +170,6 @@ Route::middleware(['auth:sanctum', 'role:editor|admin|superadmin'])->group(funct
     Route::put('/terms', [SiteinfoController::class, 'updateTerms']);
     Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy']);
     Route::post('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
-    Route::put('/customer-message/enabled', [SiteinfoController::class, 'toggleCustomerMessageEnabled']);
 });
 
 // Ruta catch-all al final


### PR DESCRIPTION
Endpont agregado a Insominia [SiteInfo -> Activar/Desactivar Mensaje]


**Endpoints disponibles:**

  1. GET /api/siteinfo - Ahora incluye el campo customer_message_enabled (true/false)
  2. PUT /api/customer-message/enabled - Para activar/desactivar el customer message

  **Funcionalidad implementada:**

  - El valor se guarda en la tabla siteinfo con la key customer_message_enabled
  - El método show() ahora retorna customer_message_enabled: true/false
  - El método toggleCustomerMessageEnabled() permite cambiar el estado
  - Ambos endpoints retornan JSON con el valor de activado/desactivado
  - La ruta PUT requiere autenticación y rol de editor/admin/superadmin