### PR TITLE
feat/descarga-transacciones

### DIFF
--- a/app/Exports/OrdersExport.php
+++ b/app/Exports/OrdersExport.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Order;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class OrdersExport implements FromCollection, WithHeadings
+{
+    protected $start;
+    protected $end;
+    protected $client;
+    protected $totalMin;
+    protected $totalMax;
+    protected $status; 
+
+    public function __construct($start = null, $end = null, $client = null, $totalMin = null, $totalMax = null, $status = 'completed')
+    {
+        $this->start = $start ?? now()->subMonths(12)->startOfMonth()->toDateString();
+        $this->end = $end ?? now()->endOfMonth()->toDateString();
+        $this->client = $client;
+        $this->totalMin = $totalMin;
+        $this->totalMax = $totalMax;
+        $this->status = $status;
+    }
+
+    /**
+    * @return \Illuminate\Support\Collection
+    */
+    public function collection()
+    {
+        $query = Order::with('user')
+            ->where('status', $this->status)
+            ->whereBetween('created_at', [$this->start, $this->end]);
+
+        if ($this->client) {
+            $query->whereHas('user', function($q) {
+                $q->where('name', $this->client);
+            });
+        }
+        if ($this->totalMin !== null) {
+            $query->where('amount', '>=', $this->totalMin);
+        }
+        if ($this->totalMax !== null) {
+            $query->where('amount', '<=', $this->totalMax);
+        }
+
+        return $query->orderByDesc('created_at')->get()->map(function ($order) {
+            return [
+                'ID' => $order->id,
+                'Cliente' => $order->user ? $order->user->name : null,
+                'Monto' => $order->amount,
+                'Fecha' => $order->created_at ? $order->created_at->format('Y-m-d H:i') : '',
+                'Estado' => $order->status,
+            ];
+        });
+    }
+
+    public function headings(): array
+    {
+        return [
+            'ID',
+            'Cliente',
+            'Monto',
+            'Fecha',
+            'Estado'
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/ReportController.php
+++ b/app/Http/Controllers/Api/ReportController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Exports\OrdersExport;
 use App\Http\Controllers\Controller;
 use App\Models\Order;
 use App\Models\Product;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Facades\Excel;
 
 class ReportController extends Controller
 {
@@ -610,6 +612,19 @@ class ReportController extends Controller
                 }),
             ]
         ]);
+    }
+
+    public function export(Request $request)
+    {
+        $start = $request->input('start');
+        $end = $request->input('end');
+        $client = $request->input('client');
+        $totalMin = $request->input('total_min');
+        $totalMax = $request->input('total_max');
+        $status = $request->input('status', 'completed'); 
+        $fileName = 'Lista_transacciones' . now()->format('Ymd_His') . '.xlsx';
+
+        return Excel::download(new OrdersExport($start, $end, $client, $totalMin, $totalMax, $status), $fileName);
     }
 
     

--- a/app/Http/Middleware/ForceJsonResponse.php
+++ b/app/Http/Middleware/ForceJsonResponse.php
@@ -23,7 +23,11 @@ class ForceJsonResponse
         }
 
         // Excluir rutas de exportación
-        if ($request->is('api/exports/*')) {
+        if (
+            $request->is('api/orders/exports/transactions') ||
+            $request->is('api/*/exports') ||
+            $request->is('api/exports/*')
+        ) {
             return $next($request);
         }
         

--- a/routes/api.php
+++ b/routes/api.php
@@ -123,13 +123,16 @@ Route::middleware('auth:sanctum')->group(function () {
 
 
     Route::middleware(['auth:sanctum', 'permission:see-all-reports'])->group(function () {
+       
+        Route::get('/orders/exports/transactions', [ReportController::class, 'export'])->middleware('role:admin|superadmin|supervisor');
+       
         Route::post('/orders/reports', [ReportController::class, 'report']);
-
         Route::post('/orders/reports/top-product-list', [ReportController::class, 'productsSalesList']);
         Route::post('/orders/reports/transactions-list', [ReportController::class, 'transactionsList']);
         Route::post('/orders/reports/clients-list', [ReportController::class, 'clientsList']);
         Route::post('/orders/reports/failed-transactions-list', [ReportController::class, 'failedTransactionsList']);
         Route::get('/orders/reports/transaction/{id}', [ReportController::class, 'transactionId']);
+
     });
 
 });


### PR DESCRIPTION
Se agrega endpoint para descarga transacciones exitosas y fallidas

'api/orders/exports/transactions'
se agrega filtro 
'status'=>'completed' o 'status'=>'failed'