### PR TITLE
feat: agregar migracion , seeder y endpoints para settings

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Siteinfo;
+use Illuminate\Http\Request;
+
+class SettingsController extends Controller
+{
+    // Muestra la configuración actual
+    public function index()
+    {
+        $settings = Siteinfo::where('key', 'prices_settings')->first();
+        return response()->json([
+            'min_max_quantity_enabled' => $settings ? ($settings->value['min_max_quantity_enabled'] ?? false) : false,
+        ]);
+    }
+
+    // Actualiza la configuración
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'min_max_quantity_enabled' => 'required|boolean',
+        ]);
+
+        Siteinfo::updateOrCreate(
+            ['key' => 'prices_settings'],
+            ['value' => $data]
+        );
+
+        return response()->json(['message' => 'Configuración actualizada correctamente']);
+    }
+
+
+
+
+}

--- a/database/migrations/2025_07_21_213501_add_min_max_price_quantity_to_prices_table.php
+++ b/database/migrations/2025_07_21_213501_add_min_max_price_quantity_to_prices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('prices', function (Blueprint $table) {
+            $table->unsignedInteger('min_price_quantity')->default(1);
+            $table->unsignedInteger('max_price_quantity')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('prices', function (Blueprint $table) {
+            $table->dropColumn(['min_price_quantity', 'max_price_quantity']);
+        });
+    }
+};

--- a/database/seeders/SiteInfoSeeder.php
+++ b/database/seeders/SiteInfoSeeder.php
@@ -36,7 +36,7 @@ class SiteInfoSeeder extends Seeder
 
         Siteinfo::updateOrCreate(
             ['key' => 'prices_settings'],
-            ['value' => ['min_max_quantity_enabled' => true]]
+            ['value' => ['min_max_quantity_enabled' => false]]
         );
     }
 } 

--- a/database/seeders/SiteInfoSeeder.php
+++ b/database/seeders/SiteInfoSeeder.php
@@ -33,5 +33,10 @@ class SiteInfoSeeder extends Seeder
                 ]
             );
         }
+
+        Siteinfo::updateOrCreate(
+            ['key' => 'prices_settings'],
+            ['value' => ['min_max_quantity_enabled' => true]]
+        );
     }
 } 

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,10 +23,7 @@ use App\Http\Controllers\Api\RoleController;
 use App\Http\Controllers\Api\SiteinfoController;
 use App\Http\Controllers\Api\WebpayController;
 use App\Http\Controllers\Api\FaqController;
-
-
-
-
+use App\Http\Controllers\SettingsController;
 
 Route::prefix('auth')->group(function () {
     Route::post('/token', [AuthController::class, 'login'])->name('auth.token.store');
@@ -176,6 +173,11 @@ Route::middleware(['auth:sanctum', 'role:editor|admin|superadmin'])->group(funct
     Route::put('/terms', [SiteinfoController::class, 'updateTerms']);
     Route::put('/privacy-policy', [SiteinfoController::class, 'updatePrivacyPolicy']);
     Route::post('/customer-message', [SiteinfoController::class, 'updateCustomerMessage']);
+});
+
+Route::middleware(['auth:sanctum', 'role:admin|superadmin'])->group(function () {
+    Route::get('/settings/prices', [SettingsController::class, 'index']);
+    Route::put('/settings/prices', [SettingsController::class, 'update']);
 });
 
 // Ruta catch-all al final

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,0 +1,48 @@
+<?php
+use App\Models\User;
+use App\Models\Siteinfo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+    $this->admin = $admin;
+});
+
+test('un admin puede ver la configuración de precios por cantidad', function () {
+    Siteinfo::updateOrCreate(
+        ['key' => 'prices_settings'],
+        ['value' => ['min_max_quantity_enabled' => true]]
+    );
+
+    $response = $this->actingAs($this->admin, 'sanctum')
+        ->getJson('/api/settings/prices');
+
+    $response->assertStatus(200);
+});
+
+test('un admin puede actualizar la configuración de precios por cantidad', function () {
+    $response = $this->actingAs($this->admin, 'sanctum')
+        ->putJson('/api/settings/prices', [
+            'min_max_quantity_enabled' => false,
+        ]);
+
+    $response->assertStatus(200);
+
+    $this->assertDatabaseHas('siteinfo', [
+        'key' => 'prices_settings',
+    ]);
+    $this->assertTrue(Siteinfo::where('key', 'prices_settings')->first()->value['min_max_quantity_enabled'] === false);
+});
+
+test('un usuario sin rol admin o superadmin no puede acceder a la configuración', function () {
+    $user = User::factory()->create();
+    $user->assignRole('cliente');
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson('/api/settings/prices');
+
+    $response->assertStatus(403);
+});

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -20,10 +20,18 @@ test('un admin puede ver la configuración de precios por cantidad', function ()
     $response = $this->actingAs($this->admin, 'sanctum')
         ->getJson('/api/settings/prices');
 
-    $response->assertStatus(200);
+    $response->assertStatus(200)
+        ->assertJson([
+            'min_max_quantity_enabled' => true,
+        ]);
 });
 
 test('un admin puede actualizar la configuración de precios por cantidad', function () {
+    Siteinfo::updateOrCreate(
+        ['key' => 'prices_settings'],
+        ['value' => ['min_max_quantity_enabled' => true]]
+    );
+
     $response = $this->actingAs($this->admin, 'sanctum')
         ->putJson('/api/settings/prices', [
             'min_max_quantity_enabled' => false,


### PR DESCRIPTION
agregar endpoints para settings (prices min_max)
migracion , seeder, test

endpoint:
GET /api/settings/prices (obtener settings)
PUT /api/settings/prices (actualizar settings)

