### PR TITLE
refactor: Elimina el permiso 'see-all-permissions' y actualiza las rutas para utilizar 'read-all-permissions' y 'read-all-roles' en la configuración de autorización

### DIFF
--- a/config/authorization/permissions.php
+++ b/config/authorization/permissions.php
@@ -117,7 +117,6 @@ return [
 
     // Permissions
     'read-all-permissions', // [superadmin, admin]
-    'see-all-permissions', // [superadmin, admin]
 
     // Roles permissions
     'read-all-roles', // [superadmin]

--- a/config/authorization/roles.php
+++ b/config/authorization/roles.php
@@ -64,8 +64,6 @@ return [
         "update-faqs",
         "delete-faqs",
 
-        // List permissions names
-        "see-all-permissions",
     ],
     'admin' => [
         'read-users',
@@ -128,8 +126,6 @@ return [
         "update-faqs",
         "delete-faqs",
 
-        // List permissions names
-        "see-all-permissions",
     ],
     'supervisor' => [
         'read-own-profile',

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,13 +68,14 @@ Route::middleware('auth:sanctum')->group(function () {
 //    Route::delete('/users/{id}', [UserController::class, 'destroy'])->middleware('permission:manage-users');
 
     Route::resource('permissions', \App\Http\Controllers\Api\PermissionController::class, ['only' => 'index'])
-        ->middleware('permission:see-all-permissions');
+        ->middleware('permission:read-all-permissions');
 
-    Route::middleware(['role:admin|superadmin'])->group(function () {
-        Route::get('/roles', [RoleController::class, 'index']);
-        Route::get('/roles/users', [RoleController::class, 'rolesWithUsers']);
-        Route::get('/roles/{user}', [RoleController::class, 'userRoles']);
-    });
+    Route::get('/roles', [RoleController::class, 'index'])
+        ->middleware('permission:read-all-roles');
+    Route::get('/roles/users', [RoleController::class, 'rolesWithUsers'])
+        ->middleware('permission:read-user-roles');
+    Route::get('/roles/{user}', [RoleController::class, 'userRoles'])
+        ->middleware('permission:read-user-roles');
 
     Route::resource('addresses', AddressController::class)
         ->only(['index', 'store', 'show', 'update', 'destroy'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,11 +71,14 @@ Route::middleware('auth:sanctum')->group(function () {
         ->middleware('permission:read-all-permissions');
 
     Route::get('/roles', [RoleController::class, 'index'])
-        ->middleware('permission:read-all-roles');
+        ->middleware('permission:read-all-roles')
+        ->name('roles.index');
     Route::get('/roles/users', [RoleController::class, 'rolesWithUsers'])
-        ->middleware('permission:read-user-roles');
+        ->middleware('permission:read-user-roles')
+        ->name('roles.users');
     Route::get('/roles/{user}', [RoleController::class, 'userRoles'])
-        ->middleware('permission:read-user-roles');
+        ->middleware('permission:read-user-roles')
+        ->name('roles.user');
 
     Route::resource('addresses', AddressController::class)
         ->only(['index', 'store', 'show', 'update', 'destroy'])

--- a/tests/Feature/RolesTest.php
+++ b/tests/Feature/RolesTest.php
@@ -6,52 +6,219 @@ use Spatie\Permission\Models\Permission;
 beforeEach(function () {
     Role::firstOrCreate(['name' => 'admin']);
     Role::firstOrCreate(['name' => 'superadmin']);
-    Role::firstOrCreate(['name' => 'cliente']);
+    Role::firstOrCreate(['name' => 'customer']);
     Role::firstOrCreate(['name' => 'supervisor']);
     Role::firstOrCreate(['name' => 'editor']);
     
-    // Crear algunos permisos para testing
+    // Crear permisos relevantes para testing
+    Permission::firstOrCreate(['name' => 'read-all-roles']);
+    Permission::firstOrCreate(['name' => 'read-user-roles']);
     Permission::firstOrCreate(['name' => 'see-all-reports']);
     Permission::firstOrCreate(['name' => 'manage-users']);
     Permission::firstOrCreate(['name' => 'see-own-purchases']);
+    
+    // Asignar permisos a roles
+    $superadmin = Role::findByName('superadmin');
+    $admin = Role::findByName('admin');
+    
+    $superadmin->givePermissionTo(['read-all-roles', 'read-user-roles']);
+    $admin->givePermissionTo(['read-user-roles']);
 });
 
-test('admin and superadmin can list roles and permissions', function () {
-    $admin = User::factory()->create();
-    $admin->assignRole('admin');
-
+// Tests para ruta GET /api/roles - Requiere permiso 'read-all-roles'
+test('superadmin can access roles index with read-all-roles permission', function () {
     $superadmin = User::factory()->create();
     $superadmin->assignRole('superadmin');
 
-    $route = '/api/roles/users'; 
+    $response = $this->actingAs($superadmin, 'sanctum')
+        ->getJson('/api/roles');
 
-    // Admin puede acceder
-    $this->actingAs($admin, 'sanctum')
-        ->getJson($route)
-        ->assertStatus(200);
-
-    // Superadmin puede acceder
-    $this->actingAs($superadmin, 'sanctum')
-        ->getJson($route)
-        ->assertStatus(200);
+    $response->assertStatus(200);
 });
 
-test('other users cannot list roles and permissions', function () {
-    $user = User::factory()->create();
-    $user->assignRole('cliente'); 
-
-    $route = '/api/roles/users';
-
-    $this->actingAs($user, 'sanctum')
-        ->getJson($route)
-        ->assertStatus(403); 
-});
-
-test('admin can get all roles without pagination', function () {
+test('admin cannot access roles index without read-all-roles permission', function () {
     $admin = User::factory()->create();
     $admin->assignRole('admin');
 
     $response = $this->actingAs($admin, 'sanctum')
+        ->getJson('/api/roles');
+
+    $response->assertStatus(403);
+});
+
+test('supervisor cannot access roles index', function () {
+    $supervisor = User::factory()->create();
+    $supervisor->assignRole('supervisor');
+
+    $response = $this->actingAs($supervisor, 'sanctum')
+        ->getJson('/api/roles');
+
+    $response->assertStatus(403);
+});
+
+test('editor cannot access roles index', function () {
+    $editor = User::factory()->create();
+    $editor->assignRole('editor');
+
+    $response = $this->actingAs($editor, 'sanctum')
+        ->getJson('/api/roles');
+
+    $response->assertStatus(403);
+});
+
+test('customer cannot access roles index', function () {
+    $customer = User::factory()->create();
+    $customer->assignRole('customer');
+
+    $response = $this->actingAs($customer, 'sanctum')
+        ->getJson('/api/roles');
+
+    $response->assertStatus(403);
+});
+
+test('unauthenticated user cannot access roles index', function () {
+    $response = $this->getJson('/api/roles');
+
+    $response->assertStatus(401);
+});
+
+// Tests para ruta GET /api/roles/users - Requiere permiso 'read-user-roles'
+test('superadmin can access roles with users with read-user-roles permission', function () {
+    $superadmin = User::factory()->create();
+    $superadmin->assignRole('superadmin');
+
+    $response = $this->actingAs($superadmin, 'sanctum')
+        ->getJson('/api/roles/users');
+
+    $response->assertStatus(200);
+});
+
+test('admin can access roles with users with read-user-roles permission', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+
+    $response = $this->actingAs($admin, 'sanctum')
+        ->getJson('/api/roles/users');
+
+    $response->assertStatus(200);
+});
+
+test('supervisor cannot access roles with users without permission', function () {
+    $supervisor = User::factory()->create();
+    $supervisor->assignRole('supervisor');
+
+    $response = $this->actingAs($supervisor, 'sanctum')
+        ->getJson('/api/roles/users');
+
+    $response->assertStatus(403);
+});
+
+test('editor cannot access roles with users without permission', function () {
+    $editor = User::factory()->create();
+    $editor->assignRole('editor');
+
+    $response = $this->actingAs($editor, 'sanctum')
+        ->getJson('/api/roles/users');
+
+    $response->assertStatus(403);
+});
+
+test('customer cannot access roles with users without permission', function () {
+    $customer = User::factory()->create();
+    $customer->assignRole('customer');
+
+    $response = $this->actingAs($customer, 'sanctum')
+        ->getJson('/api/roles/users');
+
+    $response->assertStatus(403);
+});
+
+test('unauthenticated user cannot access roles with users', function () {
+    $response = $this->getJson('/api/roles/users');
+
+    $response->assertStatus(401);
+});
+
+// Tests para ruta GET /api/roles/{user} - Requiere permiso 'read-user-roles'
+test('superadmin can access user roles with read-user-roles permission', function () {
+    $superadmin = User::factory()->create();
+    $superadmin->assignRole('superadmin');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($superadmin, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(200);
+});
+
+test('admin can access user roles with read-user-roles permission', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($admin, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(200);
+});
+
+test('supervisor cannot access user roles without permission', function () {
+    $supervisor = User::factory()->create();
+    $supervisor->assignRole('supervisor');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($supervisor, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(403);
+});
+
+test('editor cannot access user roles without permission', function () {
+    $editor = User::factory()->create();
+    $editor->assignRole('editor');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($editor, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(403);
+});
+
+test('customer cannot access user roles without permission', function () {
+    $customer = User::factory()->create();
+    $customer->assignRole('customer');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($customer, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(403);
+});
+
+test('unauthenticated user cannot access user roles', function () {
+    $targetUser = User::factory()->create();
+    
+    $response = $this->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(401);
+});
+
+// Tests de estructura de respuestas
+test('roles index returns correct data structure', function () {
+    $superadmin = User::factory()->create();
+    $superadmin->assignRole('superadmin');
+
+    $response = $this->actingAs($superadmin, 'sanctum')
         ->getJson('/api/roles');
 
     $response->assertStatus(200)
@@ -70,99 +237,60 @@ test('admin can get all roles without pagination', function () {
     $roleNames = array_column($data, 'name');
     
     expect($roleNames)->toContain('admin');
-    expect($roleNames)->toContain('cliente');
+    expect($roleNames)->toContain('customer');
     expect($roleNames)->toContain('superadmin');
+    expect($roleNames)->toContain('supervisor');
+    expect($roleNames)->toContain('editor');
 });
 
-test('superadmin can get all roles without pagination', function () {
+test('roles with users returns correct data structure', function () {
     $superadmin = User::factory()->create();
     $superadmin->assignRole('superadmin');
+    
+    // Crear usuario con rol para verificar estructura
+    $testUser = User::factory()->create();
+    $testUser->assignRole('customer');
 
     $response = $this->actingAs($superadmin, 'sanctum')
-        ->getJson('/api/roles');
+        ->getJson('/api/roles/users');
 
     $response->assertStatus(200)
         ->assertJsonStructure([
             '*' => [
-                'id',
-                'name',
-                'permissions',
-                'created_at',
-                'updated_at'
+                'role',
+                'users' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'email'
+                    ]
+                ]
             ]
         ]);
+});
 
-    // Verificar que cada rol tiene la estructura correcta
+test('user roles returns correct data structure', function () {
+    $superadmin = User::factory()->create();
+    $superadmin->assignRole('superadmin');
+    
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('customer');
+
+    $response = $this->actingAs($superadmin, 'sanctum')
+        ->getJson("/api/roles/{$targetUser->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'user_id',
+            'user_name',
+            'roles',
+            'permissions'
+        ])
+        ->assertJsonPath('user_id', $targetUser->id)
+        ->assertJsonPath('user_name', $targetUser->name);
+        
     $data = $response->json();
-    foreach ($data as $role) {
-        expect($role)->toHaveKeys(['id', 'name', 'permissions', 'created_at', 'updated_at']);
-        expect($role['permissions'])->toBeArray();
-    }
+    expect($data['roles'])->toBeArray();
+    expect($data['permissions'])->toBeArray();
 });
 
-test('non-admin users cannot get roles list', function () {
-    $user = User::factory()->create();
-    $user->assignRole('cliente');
-
-    $response = $this->actingAs($user, 'sanctum')
-        ->getJson('/api/roles');
-
-    $response->assertStatus(403);
-});
-
-test('supervisor cannot get roles list', function () {
-    $supervisor = User::factory()->create();
-    $supervisor->assignRole('supervisor');
-
-    $response = $this->actingAs($supervisor, 'sanctum')
-        ->getJson('/api/roles');
-
-    $response->assertStatus(403);
-});
-
-test('editor cannot get roles list', function () {
-    $editor = User::factory()->create();
-    $editor->assignRole('editor');
-
-    $response = $this->actingAs($editor, 'sanctum')
-        ->getJson('/api/roles');
-
-    $response->assertStatus(403);
-});
-
-test('unauthenticated users cannot get roles list', function () {
-    $response = $this->getJson('/api/roles');
-
-    $response->assertStatus(401);
-});
-
-test('roles endpoint returns correct data structure', function () {
-    $admin = User::factory()->create();
-    $admin->assignRole('admin');
-
-    // Asignar algunos permisos a un rol para verificar la estructura
-    $role = Role::findByName('admin');
-    $role->givePermissionTo(['see-all-reports', 'manage-users']);
-
-    $response = $this->actingAs($admin, 'sanctum')
-        ->getJson('/api/roles');
-
-    $response->assertStatus(200);
-
-    $data = $response->json();
-    
-    // Verificar que es un array
-    expect($data)->toBeArray();
-    
-    // Buscar el rol admin en la respuesta
-    $adminRole = collect($data)->firstWhere('name', 'admin');
-    
-    expect($adminRole)->not->toBeNull();
-    expect($adminRole['id'])->toBeInt();
-    expect($adminRole['name'])->toBe('admin');
-    expect($adminRole['permissions'])->toBeArray();
-    expect($adminRole['permissions'])->toContain('see-all-reports');
-    expect($adminRole['permissions'])->toContain('manage-users');
-    expect($adminRole['created_at'])->toBeString();
-    expect($adminRole['updated_at'])->toBeString();
-});


### PR DESCRIPTION
Esta *pull request* actualiza la lógica de autorización relacionada con los permisos y roles, principalmente eliminando el permiso `see-all-permissions` y refactorizando cómo se verifican los permisos y roles en las rutas de la API. Los cambios mejoran la claridad y consistencia en las comprobaciones de permisos para acceder a los endpoints de permisos y roles.

### **Actualizaciones en la lógica de autorización:**
* Se eliminó el permiso `see-all-permissions` de la configuración de permisos (`config/authorization/permissions.php`) y de los roles asignados a `admin` y `supervisor` (`config/authorization/roles.php`).
  [\[1\]](diffhunk://#diff-b931a714d718b0118effdad6bf6ec3bcf1bbd93e78ca44a9a99b7b88ac8fb4f4L120)  [\[2\]](diffhunk://#diff-214484b2a47d6b5bcd50273390c4b41d5c6027286eb5ba83ed9a8f591c9f2325L67-L68)  [\[3\]](diffhunk://#diff-214484b2a47d6b5bcd50273390c4b41d5c6027286eb5ba83ed9a8f591c9f2325L131-L132)

* Se actualizaron las rutas de la API para usar los permisos `read-all-permissions`, `read-all-roles` y `read-user-roles` al acceder a los endpoints de permisos y roles, reemplazando el uso anterior de `see-all-permissions` y el *middleware* basado en roles. (`routes/api.php`)
