### PR TITLE
fix(product): #360 - Repara salida API cuando un producto no tiene categorias o marcas

### DIFF
--- a/app/Http/Resources/Products/ProductCollection.php
+++ b/app/Http/Resources/Products/ProductCollection.php
@@ -35,16 +35,16 @@ class ProductCollection extends ResourceCollection
                 'id' => $product->id,
                 'name' => $product->name,
                 'category' => [
-                    'id' => $product->category->id,
-                    'name' => $product->category->name,
+                    'id' => $product->category->id ?? null,
+                    'name' => $product->category->name ?? null,
                 ],
                 'subcategory' => [
-                    'id' => $product->subcategory->id,
-                    'name' => $product->subcategory->name,
+                    'id' => $product->subcategory->id ?? null,
+                    'name' => $product->subcategory->name ?? null,
                 ],
                 'brand' => [
-                    'id' => $product->brand->id,
-                    'name' => $product->brand->name,
+                    'id' => $product->brand->id ?? null,
+                    'name' => $product->brand->name ?? null,
                 ],
                 'unit' => $product->joined_unit
                     ?? optional($product->prices()->where('is_active', true)->orderByDesc('valid_from')->first())->unit,

--- a/app/Http/Resources/Products/ProductCollection.php
+++ b/app/Http/Resources/Products/ProductCollection.php
@@ -34,18 +34,18 @@ class ProductCollection extends ResourceCollection
             return [
                 'id' => $product->id,
                 'name' => $product->name,
-                'category' => [
-                    'id' => $product->category->id ?? null,
-                    'name' => $product->category->name ?? null,
-                ],
-                'subcategory' => [
-                    'id' => $product->subcategory->id ?? null,
-                    'name' => $product->subcategory->name ?? null,
-                ],
-                'brand' => [
-                    'id' => $product->brand->id ?? null,
-                    'name' => $product->brand->name ?? null,
-                ],
+                'category' => $product->category ? [
+                    'id' => $product->category->id,
+                    'name' => $product->category->name,
+                ] : null,
+                'subcategory' => $product->subcategory ? [
+                    'id' => $product->subcategory->id,
+                    'name' => $product->subcategory->name,
+                ] : null,
+                'brand' => $product->brand ? [
+                    'id' => $product->brand->id,
+                    'name' => $product->brand->name,
+                ] : null,
                 'unit' => $product->joined_unit
                     ?? optional($product->prices()->where('is_active', true)->orderByDesc('valid_from')->first())->unit,
                 'price' => isset($product->joined_price)


### PR DESCRIPTION
Existen "producto ejemplo" en la DB sin datos completos

<img width="427" height="378" alt="image" src="https://github.com/user-attachments/assets/ba0d3ee4-d208-487f-bd3f-494e51a7c32a" />
