### PR TITLE
Feat/conf queue qa 368

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -47,4 +47,3 @@ jobs:
       - name: Bring the application out of maintenance mode
         run: docker compose -f compose.qa.yml exec app php artisan up
         working-directory: /home/ubuntu/deploys/socomarca-backend
-

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -47,3 +47,7 @@ jobs:
       - name: Bring the application out of maintenance mode
         run: docker compose -f compose.qa.yml exec app php artisan up
         working-directory: /home/ubuntu/deploys/socomarca-backend
+
+      - name: Restart worker service
+        run: docker compose -f compose.qa.yml up -d --build worker
+        working-directory: /home/ubuntu/deploys/socomarca-backend

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -48,6 +48,3 @@ jobs:
         run: docker compose -f compose.qa.yml exec app php artisan up
         working-directory: /home/ubuntu/deploys/socomarca-backend
 
-      - name: Restart worker service
-        run: docker compose -f compose.qa.yml up -d --build worker
-        working-directory: /home/ubuntu/deploys/socomarca-backend

--- a/compose.qa.yml
+++ b/compose.qa.yml
@@ -14,3 +14,15 @@ services:
     environment:
       - PHP_UPLOAD_MAX_FILESIZE=100M
       - PHP_POST_MAX_SIZE=100M
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: socomarca_worker_qa
+    restart: unless-stopped
+    volumes:
+      - .:/var/www/html:cached
+      - ./phpcustom.ini:/usr/local/etc/php/conf.d/custom.ini
+    command: php artisan queue:work
+    depends_on:
+      - app

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,21 @@ services:
       - DEFAULT_REGION=us-east-1
     networks:
       - socomarca
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: socomarca_worker
+    restart: unless-stopped
+    volumes:
+      - .:/var/www/html:cached
+      - ./phpcustom.ini:/usr/local/etc/php/conf.d/custom.ini
+    command: "php artisan queue:work"
+    depends_on:
+      - workcontainer
+      - db
+    networks:
+      - socomarca
 volumes:
   socomarca_data:
     name: socomarca_data


### PR DESCRIPTION
Agregar como contenedor php artisan queue:work

se agrega al compose.yml para desarrollo local
y compose.qa.yml para el servidor qa