### PR TITLE
Feat: Viewed notifications

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\Notifications\StoreNotificationRequest;
 use App\Jobs\SendPushNotification;
 use App\Models\FcmNotificationHistory;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 
 
@@ -15,7 +17,17 @@ class NotificationController extends Controller
 
     public function index()
     {
-        $history = FcmNotificationHistory::orderByDesc('sent_at')
+        $userId = Auth::user()->id;
+
+        $history = FcmNotificationHistory::select(
+            'fcm_notification_histories.*',
+            DB::raw('CASE WHEN viewed_notifications.id IS NOT NULL THEN true ELSE false END as viewed')
+        )
+            ->leftJoin('viewed_notifications', function ($join) use ($userId) {
+                $join->on('fcm_notification_histories.id', '=', 'viewed_notifications.fcm_notification_id')
+                     ->where('viewed_notifications.user_id', '=', $userId);
+            })
+            ->orderByDesc('sent_at')
             ->paginate(20);
 
         return response()->json($history);

--- a/app/Http/Controllers/Api/ViewedNotificationsBatchStoreController.php
+++ b/app/Http/Controllers/Api/ViewedNotificationsBatchStoreController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ViewedNotifications\ViewedNotificationsBatchStoreRequest;
+use App\Http\Resources\ViewedNotificationResource;
+use App\Models\ViewedNotification;
+use Illuminate\Http\JsonResponse;
+
+class ViewedNotificationsBatchStoreController extends Controller
+{
+    public function __invoke(ViewedNotificationsBatchStoreRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+        $userId = $request->user()->id;
+
+        $createdNotifications = [];
+
+        foreach ($validated['resources'] as $resource) {
+            $viewedNotification = ViewedNotification::firstOrCreate(
+                [
+                    'fcm_notification_id' => $resource['fcm_notification_id'],
+                    'user_id' => $userId,
+                ]
+            );
+
+            $createdNotifications[] = [
+                'id' => $viewedNotification->id,
+                'fcm_notification_id' => $viewedNotification->fcm_notification_id,
+                'created_at' => $viewedNotification->created_at->toIso8601String(),
+            ];
+        }
+
+        return response()->json([
+            'data' => $createdNotifications,
+        ], 201);
+    }
+}

--- a/app/Http/Requests/ViewedNotifications/ViewedNotificationsBatchStoreRequest.php
+++ b/app/Http/Requests/ViewedNotifications/ViewedNotificationsBatchStoreRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\ViewedNotifications;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ViewedNotificationsBatchStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'resources' => 'required|array|min:1',
+            'resources.*.fcm_notification_id' => 'required|integer|exists:fcm_notification_histories,id',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'resources.required' => 'El campo resources es requerido',
+            'resources.array' => 'El campo resources debe ser un array',
+            'resources.min' => 'Debe proporcionar al menos una notificación',
+            'resources.*.fcm_notification_id.required' => 'El fcm_notification_id es requerido',
+            'resources.*.fcm_notification_id.integer' => 'El fcm_notification_id debe ser un número entero',
+            'resources.*.fcm_notification_id.exists' => 'La notificación especificada no existe',
+        ];
+    }
+}

--- a/app/Models/FcmNotificationHistory.php
+++ b/app/Models/FcmNotificationHistory.php
@@ -1,10 +1,13 @@
 <?php
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class FcmNotificationHistory extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'user_id',
         'title',

--- a/app/Models/ViewedNotification.php
+++ b/app/Models/ViewedNotification.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ViewedNotification extends Model
+{
+    protected $fillable = [
+        'fcm_notification_id',
+        'user_id',
+    ];
+
+    public function fcmNotification(): BelongsTo
+    {
+        return $this->belongsTo(FcmNotificationHistory::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Policies/ViewedNotificationPolicy.php
+++ b/app/Policies/ViewedNotificationPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\ViewedNotification;
+
+class ViewedNotificationPolicy
+{
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo('create-viewed-notifications');
+    }
+}

--- a/config/authorization/permissions.php
+++ b/config/authorization/permissions.php
@@ -130,6 +130,7 @@ return [
     // Notification permissions
     'create-notifications', // [superadmin, admin]
     'read-all-notifications', // [superadmin, admin, customer]
+    'create-viewed-notifications', // [superadmin, admin, supervisor, editor, customer]
 
     'update-system-config' // [superadmin, admin]
 ];

--- a/config/authorization/roles.php
+++ b/config/authorization/roles.php
@@ -57,6 +57,7 @@ return [
         // Notification related permissions
         "create-notifications",
         "read-all-notifications",
+        "create-viewed-notifications",
         "update-system-config",
 
     ],
@@ -116,6 +117,7 @@ return [
         // Notification related permissions
         "create-notifications",
         "read-all-notifications",
+        "create-viewed-notifications",
 
     ],
     'supervisor' => [
@@ -139,6 +141,7 @@ return [
         'read-all-categories-export',
 
         'read-all-notifications',
+        'create-viewed-notifications',
 
     ],
     'editor' => [
@@ -164,6 +167,7 @@ return [
         "create-faqs",
         "update-faqs",
         "delete-faqs",
+        'create-viewed-notifications',
     ],
     'customer' => [
         'read-own-profile',
@@ -205,5 +209,6 @@ return [
         'read-content-settings',
 
         "read-all-notifications",
+        'create-viewed-notifications',
     ],
 ];

--- a/database/factories/FcmNotificationHistoryFactory.php
+++ b/database/factories/FcmNotificationHistoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\FcmNotificationHistory>
+ */
+class FcmNotificationHistoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'title' => $this->faker->sentence(),
+            'message' => $this->faker->paragraph(),
+            'sent_at' => $this->faker->dateTime(),
+        ];
+    }
+}

--- a/database/migrations/2026_03_03_215256_create_viewed_notifications_table.php
+++ b/database/migrations/2026_03_03_215256_create_viewed_notifications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('viewed_notifications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('fcm_notification_id')
+                  ->constrained('fcm_notification_histories')
+                  ->onDelete('cascade');
+            $table->foreignId('user_id')
+                  ->constrained('users')
+                  ->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['fcm_notification_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('viewed_notifications');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Api\WebpayController;
 use App\Http\Controllers\Api\FaqController;
 use App\Http\Controllers\Api\FirebaseConfigController;
 use App\Http\Controllers\Api\NotificationController;
+use App\Http\Controllers\Api\ViewedNotificationsBatchStoreController;
 use App\Http\Controllers\Api\ProductImageSyncController;
 use App\Http\Controllers\SettingsController;
 
@@ -273,6 +274,10 @@ Route::middleware(['auth:sanctum', 'permission:create-notifications'])->group(fu
     Route::post('/notifications', [NotificationController::class, 'store'])
         ->name('notifications.store');
 });
+
+Route::post('/viewed-notifications/batch', ViewedNotificationsBatchStoreController::class)
+    ->middleware(['auth:sanctum', 'can:create,App\Models\ViewedNotification'])
+    ->name('viewed-notifications.batchStore');
 
 Route::middleware(['auth:sanctum', 'permission:update-system-config'])
     ->put('fcm/config', [FirebaseConfigController::class, 'update'])

--- a/tests/Feature/NotificationControllerTest.php
+++ b/tests/Feature/NotificationControllerTest.php
@@ -210,10 +210,44 @@ describe('Notification API', function () {
             $response = $this->getJson(route('notifications.index'));
 
             $response->assertStatus(200)
+                ->assertJsonStructure([
+                    'current_page',
+                    'data' => [
+                        '*' => [
+                            'id',
+                            'user_id',
+                            'title',
+                            'message',
+                            'viewed',
+                            'sent_at'
+                        ]
+                    ],
+                    'first_page_url',
+                    'from',
+                    'last_page',
+                    'last_page_url',
+                    'links' => [
+                        '*' => [
+                            'url',
+                            'label',
+                            'active'
+                        ]
+                    ],
+                    'next_page_url',
+                    'path',
+                    'per_page',
+                    'prev_page_url',
+                    'to',
+                    'total'
+                ])
                 ->assertJsonFragment([
                     'title' => 'Historial FCM',
                     'message' => 'Mensaje historial',
-                ]);
+                ])
+                ->assertJsonPath('data.0.viewed', false)
+                ->assertJsonPath('current_page', 1)
+                ->assertJsonPath('per_page', 20)
+                ->assertJsonPath('total', 1);
         });
 
         it('does not save history if user does not have permission', function () {

--- a/tests/Feature/ViewedNotificationTest.php
+++ b/tests/Feature/ViewedNotificationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FcmNotificationHistory;
+use App\Models\User;
+use App\Models\ViewedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ViewedNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_batch_store_viewed_notifications(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('create-viewed-notifications');
+        $notifications = FcmNotificationHistory::factory()->count(3)->create();
+
+        $response = $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [
+                ['fcm_notification_id' => $notifications[0]->id],
+                ['fcm_notification_id' => $notifications[1]->id],
+            ]
+        ]);
+
+        $response->assertStatus(201)
+                 ->assertJsonCount(2, 'data');
+
+        $this->assertDatabaseCount('viewed_notifications', 2);
+    }
+
+    public function test_only_user_who_viewed_sees_notification_as_viewed(): void
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+        $notification = FcmNotificationHistory::factory()->create();
+
+        // Assign permissions to users
+        $userA->givePermissionTo('create-viewed-notifications');
+        $userB->givePermissionTo('create-viewed-notifications');
+
+        // User A marks as viewed
+        $this->actingAs($userA)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ])->assertStatus(201);
+
+        // Check User A sees as viewed
+        $userA->givePermissionTo('read-all-notifications');
+        $responseA = $this->actingAs($userA)->getJson('/api/notifications');
+        $this->assertTrue($responseA->json('data.0.viewed'));
+
+        // Check User B doesn't see as viewed
+        $userB->givePermissionTo('read-all-notifications');
+        $responseB = $this->actingAs($userB)->getJson('/api/notifications');
+        $this->assertFalse($responseB->json('data.0.viewed'));
+    }
+
+    public function test_batch_store_requires_valid_notification_ids(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('create-viewed-notifications');
+
+        $response = $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [
+                ['fcm_notification_id' => 99999],
+            ]
+        ]);
+
+        $response->assertStatus(422)
+                 ->assertJsonValidationErrors('resources.0.fcm_notification_id');
+    }
+
+    public function test_batch_store_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => 1]]
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_batch_store_requires_permission(): void
+    {
+        $user = User::factory()->create();
+        $notification = FcmNotificationHistory::factory()->create();
+
+        // User doesn't have the permission
+        $response = $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_batch_store_assigns_current_user_id(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('create-viewed-notifications');
+        $notification = FcmNotificationHistory::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ])->assertStatus(201);
+
+        $this->assertDatabaseHas('viewed_notifications', [
+            'fcm_notification_id' => $notification->id,
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_batch_store_prevents_duplicates(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('create-viewed-notifications');
+        $notification = FcmNotificationHistory::factory()->create();
+
+        // First request
+        $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ])->assertStatus(201);
+
+        // Second request with same data
+        $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ])->assertStatus(201);
+
+        // Should only have one record
+        $this->assertDatabaseCount('viewed_notifications', 1);
+    }
+
+    public function test_notification_index_shows_viewed_field(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['read-all-notifications', 'create-viewed-notifications']);
+        $notification = FcmNotificationHistory::factory()->create();
+
+        // Mark as viewed
+        $this->actingAs($user)->postJson('/api/viewed-notifications/batch', [
+            'resources' => [['fcm_notification_id' => $notification->id]]
+        ]);
+
+        // Get notifications
+        $response = $this->actingAs($user)->getJson('/api/notifications');
+
+        $response->assertStatus(200)
+                 ->assertJsonPath('data.0.viewed', true);
+    }
+}


### PR DESCRIPTION
# Viewed Notifications System

## New Endpoint: `POST /api/viewed-notifications/batch`

Allows users to mark FCM notifications as viewed in bulk.

### Request
```json
{
  "resources": [
    { "fcm_notification_id": 3 },
    { "fcm_notification_id": 5 }
  ]
}
```

### Response (201 Created)
```json
{
  "data": [
    {
      "id": 1,
      "fcm_notification_id": 3,
      "created_at": "2026-03-03T23:39:58.476987Z"
    },
    {
      "id": 2,
      "fcm_notification_id": 5,
      "created_at": "2026-03-03T23:39:58.476987Z"
    }
  ]
}
```

### Features
- **Authentication:** Requires `sanctum` token
- **Authorization:** Requires `create-viewed-notifications` permission (all roles)
- **Idempotency:** Multiple identical requests do not create duplicates
- **User Isolation:** The `user_id` is automatically assigned from the authenticated user

### Changes in `GET /api/notifications`
The endpoint now returns a `viewed` field (boolean) indicating whether the authenticated user has viewed the notification:

```json
{
  "data": [
    {
      "id": 1,
      "user_id": 5,
      "title": "Unique Offers!",
      "message": "Products with discounts",
      "viewed": true,
      "sent_at": "2026-02-26 12:04:34"
    }
  ]
}
```

### Validations
- `fcm_notification_id` must exist in `fcm_notification_histories`
- Unique constraint on `(fcm_notification_id, user_id)` prevents duplicates at database level
- Only users with `create-viewed-notifications` permission can use the endpoint

### Status Codes
- `201` - Notifications saved successfully
- `401` - Not authenticated
- `403` - Permission denied
- `422` - Validation failed (e.g., notification does not exist)