### PR TITLE
fix(webpay): acepta POST en /webpay/return para retorno desde Transbank en Capacitor

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -226,7 +226,7 @@ Route::resource('faq', FaqController::class)
 //Se sacan de la autenticacion porque es confirmacion de pago.
 //Front recibe el token y lo envia a /webpay/return  (La ruta se establece en el webpayService: linea 59)
 ///webpay/return valida la token y entrega al front el estado del pago
-Route::get('/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
+Route::match(['get', 'post'], '/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
 Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
 


### PR DESCRIPTION
## Contexto

En la app móvil (Capacitor), el flujo de pago con Transbank Webpay Plus falla al intentar retornar a la app después del pago. El usuario llega correctamente al portal de Transbank, pero al finalizar el pago (exitoso o cancelado) no vuelve a la app.

## Causa raíz

Transbank redirige al usuario de vuelta a la `WEBPAY_RETURN_URL` mediante un **form POST**. La ruta del backend `/webpay/return` solo aceptaba **GET**, por lo que:
- Transbank enviaba un POST → Laravel retornaba 405 vía el catch-all
- El WebView de Capacitor quedaba mostrando un error JSON, fuera de la app

## Cambio

`routes/api.php`: cambia `Route::get` por `Route::match(['get', 'post'])` en `/webpay/return`.

Esto permite que la ruta responda tanto a las llamadas GET del frontend como al POST que envía Transbank.

## Solución completa (frontend)

El fix principal vive en el frontend: se agregó un route handler en `/api/webpay/return` que recibe el POST de Transbank, extrae el `token_ws` del body y hace un redirect 302 GET hacia `/confirmacion-pago?token_ws=TOKEN`. Esto mantiene la navegación dentro del dominio de la app y el WebView de Capacitor la sigue correctamente.

La `WEBPAY_RETURN_URL` en base de datos debe actualizarse a:
```
https://www.appsocomarca.cl/api/webpay/return
```

## Testing

- [ ] Flujo de pago exitoso en web de escritorio
- [ ] Flujo de pago exitoso en app móvil (Capacitor Android/iOS)
- [ ] Pago cancelado por el usuario (TBK_TOKEN)
- [ ] Timeout de sesión

🤖 Generated with [Claude Code](https://claude.com/claude-code)