### PR TITLE
feat(orders): cálculo de costo de envío en backend

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -61,6 +61,9 @@ class OrderController extends Controller
                 return $price->price * $cart->quantity;
             });
 
+            $shippingCost = $subtotal >= 70000 ? 0 : (int) round($subtotal * 0.1);
+            $total = $subtotal + $shippingCost;
+
             $user = User::find(Auth::user()->id);
             $address = $user->addresses()->where('id', $addressId)->first();
 
@@ -72,7 +75,8 @@ class OrderController extends Controller
             $data = [
                 'user_id' => $user->id,
                 'subtotal' => $subtotal,
-                'amount' => $subtotal,
+                'shipping_cost' => $shippingCost,
+                'amount' => $total,
                 'status' => 'pending',
                 'order_meta' => $order_meta,
             ];

--- a/app/Http/Resources/Orders/OrderResource.php
+++ b/app/Http/Resources/Orders/OrderResource.php
@@ -18,6 +18,7 @@ class OrderResource extends JsonResource
             "id" => $this->id,
             "user" => $this->user,
             "subtotal" => $this->subtotal,
+            "shipping_cost" => $this->shipping_cost,
             "amount" => $this->amount,
             "status" => $this->status,
             "order_items" => OrderItemResource::collection($this->orderDetails),

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -13,6 +13,7 @@ class Order extends Model
     protected $fillable = [
         'user_id',
         'subtotal',
+        'shipping_cost',
         'amount',
         'status',
         'order_meta'
@@ -53,6 +54,11 @@ class Order extends Model
     public function getSubtotalAttribute()
     {
         return round($this->attributes['subtotal'], 0);
+    }
+
+    public function getShippingCostAttribute()
+    {
+        return round($this->attributes['shipping_cost'] ?? 0, 0);
     }
 
     public function getMunicipalityIdAttribute()

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -48,10 +48,13 @@ class OrderFactory extends Factory
             'billing_address_details' => fake()->address(),
         ];
         
+        $shippingCost = $subtotal >= 70000 ? 0 : (int) round($subtotal * 0.1);
+
         return [
             'user_id' => User::factory(),
             'subtotal' => $subtotal,
-            'amount' => $subtotal,
+            'shipping_cost' => $shippingCost,
+            'amount' => $subtotal + $shippingCost,
             'status' => fake()->randomElement(['pending', 'processing', 'on_hold', 'completed', 'canceled', 'refunded', 'failed']),
             'order_meta' => json_encode($meta),
         ];

--- a/database/migrations/2026_04_22_000000_add_shipping_cost_to_orders_table.php
+++ b/database/migrations/2026_04_22_000000_add_shipping_cost_to_orders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->decimal('shipping_cost', 10, 2)->default(0)->after('subtotal');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('shipping_cost');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -226,7 +226,7 @@ Route::resource('faq', FaqController::class)
 //Se sacan de la autenticacion porque es confirmacion de pago.
 //Front recibe el token y lo envia a /webpay/return  (La ruta se establece en el webpayService: linea 59)
 ///webpay/return valida la token y entrega al front el estado del pago
-Route::get('/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
+Route::match(['get', 'post'], '/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
 Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -226,7 +226,7 @@ Route::resource('faq', FaqController::class)
 //Se sacan de la autenticacion porque es confirmacion de pago.
 //Front recibe el token y lo envia a /webpay/return  (La ruta se establece en el webpayService: linea 59)
 ///webpay/return valida la token y entrega al front el estado del pago
-Route::match(['get', 'post'], '/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
+Route::get('/webpay/return', [WebpayController::class, 'return'])->name('webpay.return');
 Route::get('/webpay/status', [WebpayController::class, 'status']);
 Route::post('/webpay/refund', [WebpayController::class, 'refund']);
 


### PR DESCRIPTION
## Resumen

Integra el cálculo de costo de envío directamente en el backend, de modo que el monto enviado a Webpay refleje el costo real al cliente.

**Regla:**
- Subtotal **≥ \$70.000 CLP** → envío gratis (\$0)
- Subtotal **< \$70.000 CLP** → envío = `round(subtotal × 10%)`
- `amount = subtotal + shipping_cost` (este valor se envía a Webpay)

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `database/migrations/2026_04_22_…_add_shipping_cost_to_orders_table.php` | Nueva columna `shipping_cost` en tabla `orders` |
| `app/Models/Order.php` | `shipping_cost` en `$fillable` + accessor que redondea a entero |
| `app/Http/Controllers/Api/OrderController.php` | Cálculo de envío antes de crear la orden |
| `app/Http/Resources/Orders/OrderResource.php` | Expone `shipping_cost` en la respuesta API |
| `database/factories/OrderFactory.php` | Factory actualizada con `shipping_cost` |

## Plan de prueba

- [ ] Ejecutar `php artisan migrate` en staging
- [ ] Verificar en Webpay sandbox que el monto cobrado incluye el envío cuando subtotal < \$70.000
- [ ] Verificar que el campo `shipping_cost` aparece en la respuesta del endpoint `POST /orders/pay`
- [ ] Verificar que con subtotal ≥ \$70.000 el `shipping_cost` es 0 y el `amount` igual al `subtotal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)